### PR TITLE
Fix CD_scrambling_key generation

### DIFF
--- a/i2s.c
+++ b/i2s.c
@@ -76,13 +76,13 @@ void i2s_data_thread() {
     }
 
     for (int i=6; i<1176; i++) {
-        char upper = key & 0xFF;
+        int upper = key & 0xFF;
         for(int j=0; j<8; j++) {
             int bit = ((key & 1)^((key & 2)>>1)) << 15;
             key = (bit | key) >> 1;
         }
 
-        char lower = key & 0xFF;
+        int lower = key & 0xFF;
 
         CD_scrambling_key[i] = (lower << 8) | upper;
 


### PR DESCRIPTION
After some investigation I've spotted a typo that could cause an invalid scrambling_key generation.

This PR should fix it as I get identical values to other algorithms like https://github.com/higan-emu/higan/blob/master/nall/cd/scrambler.hpp

Currently I've no way to test it in a real PSX, so it would be nice if someone could check if this makes any improvement 😉